### PR TITLE
IHDP-19 Upgrade Infinispan to 9.4.1.Final

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,6 +16,7 @@
     <description>InputFormat/OutputFormat to integrate with Hadoop Map Reduce and supported tools</description>
 
     <properties>
+        <javadoc.title>Hadoop Core :: ${branding.name} ${branding.version} API</javadoc.title>
         <server1.dist>${project.build.directory}/node1</server1.dist>
         <server2.dist>${project.build.directory}/node2</server2.dist>
     </properties>
@@ -31,14 +32,12 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-yarn-server-tests</artifactId>
             <classifier>tests</classifier>
-            <version>${version.hadoop}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-minicluster</artifactId>
-            <version>${version.hadoop}</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.netty</groupId>
@@ -55,7 +54,6 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-common</artifactId>
-            <version>${version.hadoop}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -68,7 +66,6 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
-            <version>${version.hadoop}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -81,7 +78,6 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>${version.hadoop}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -94,34 +90,29 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-client-hotrod</artifactId>
-            <version>${version.infinispan}</version>
         </dependency>
 
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-core</artifactId>
-            <version>${version.infinispan}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
-            <version>1.1.8.Final</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
-            <version>1.0.0.Final</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.infinispan.arquillian.container</groupId>
             <artifactId>infinispan-arquillian-impl</artifactId>
-            <version>${version.infinispan.arquillian}</version>
             <scope>test</scope>
         </dependency>
 
@@ -129,7 +120,6 @@
             <groupId>org.jacoco</groupId>
             <artifactId>org.jacoco.agent</artifactId>
             <classifier>runtime</classifier>
-            <version>${version.jacoco}</version>
             <scope>test</scope>
         </dependency>
 
@@ -146,7 +136,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>${version.maven.surefire}</version>
                 <configuration>
                     <forkCount>0</forkCount>
                     <reuseForks>true</reuseForks>
@@ -226,7 +216,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.18.1</version>
+                        <version>${version.maven.surefire}</version>
                         <configuration combine.self="override">
                             <argLine>-Xmx3000m -XX:MaxPermSize=512m ${jacoco.agent.argLine}</argLine>
                         </configuration>
@@ -277,6 +267,26 @@
                             <destfile>${project.build.directory}/target/jacoco.exec</destfile>
                             <datafile>${project.build.directory}/target/jacoco.exec</datafile>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>distribution</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>generate-javadoc</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>javadoc-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/core/src/main/assembly/dist.xml
+++ b/core/src/main/assembly/dist.xml
@@ -1,0 +1,31 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+  <id>dist</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <fileSets>
+    <fileSet>
+      <directory>${project.basedir}</directory>
+      <outputDirectory></outputDirectory>
+      <includes>
+        <include>LICENSE*</include>
+        <include>README*</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/core/target/site/apidocs</directory>
+      <outputDirectory>/doc/apidocs</outputDirectory>
+      <includes>
+        <include>**/**</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+  <files>
+    <file>
+        <source>${project.basedir}/core/target/infinispan-hadoop-core-${project.version}.jar</source>
+        <outputDirectory></outputDirectory>
+    </file>
+  </files>
+</assembly>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-build-configuration-parent</artifactId>
+        <version>9.4.1.Final</version>
+    </parent>
+
     <groupId>org.infinispan.hadoop</groupId>
     <artifactId>parent</artifactId>
     <version>0.4-SNAPSHOT</version>
@@ -77,7 +83,6 @@
             <name>JBoss Release Repository</name>
             <url>${jboss.releases.repo.url}</url>
         </repository>
-
         <snapshotRepository>
             <id>jboss-snapshots-repository</id>
             <name>JBoss Snapshot Repository</name>
@@ -89,24 +94,21 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2
-        </jboss.releases.repo.url>
-        <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots
-        </jboss.snapshots.repo.url>
+        <branding.name>${infinispan.brand.name}</branding.name>
+        <branding.version>${project.version}</branding.version>
+        <branding.prefix>${infinispan.brand.prefix}</branding.prefix>
 
-        <version.hadoop>3.1.1</version.hadoop>
-        <version.infinispan>9.4.0.Final</version.infinispan>
-        <version.maven.compiler>3.1</version.maven.compiler>
-        <version.maven.source>2.2.1</version.maven.source>
-        <version.maven.resources>2.6</version.maven.resources>
-        <version.maven.surefire>2.16</version.maven.surefire>
         <version.download-maven>1.4.0</version.download-maven>
-        <version.infinispan.arquillian>1.2.0.Alpha3</version.infinispan.arquillian>
+        <version.maven.javadoc>3.0.1</version.maven.javadoc>
+        <version.maven.release>2.5.3</version.maven.release>
+        <version.maven.resources>3.1.0</version.maven.resources>
+        <version.maven.shade>3.2.0</version.maven.shade>
 
-        <version.junit>4.11</version.junit>
+        <version.infinispan>9.4.1.Final</version.infinispan>
+        <version.flink>0.10.1</version.flink>
+        <version.hadoop>3.1.1</version.hadoop>
+        <version.infinispan.arquillian>1.2.0.Alpha3</version.infinispan.arquillian>
         <version.jcipannotations>1.0</version.jcipannotations>
-        <version.jboss.logging>3.1.4.GA</version.jboss.logging>
-        <version.jacoco>0.7.5.201505241946</version.jacoco>
     </properties>
 
     <repositories>
@@ -144,6 +146,17 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-core</artifactId>
+                <version>${version.infinispan}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-client-hotrod</artifactId>
+                <version>${version.infinispan}</version>
+            </dependency>
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${version.junit}</version>
@@ -166,7 +179,60 @@
                 <artifactId>hadoop-mapreduce-client-core</artifactId>
                 <version>${version.hadoop}</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-yarn-server-tests</artifactId>
+                <version>${version.hadoop}</version>
+                <classifier>tests</classifier>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-minicluster</artifactId>
+                <version>${version.hadoop}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-mapreduce-client-common</artifactId>
+                <version>${version.hadoop}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-common</artifactId>
+                <version>${version.hadoop}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jacoco</groupId>
+                <artifactId>org.jacoco.agent</artifactId>
+                <version>${version.jacoco}</version>
+                <classifier>runtime</classifier>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian.junit</groupId>
+                <artifactId>arquillian-junit-container</artifactId>
+                <version>${version.arquillian}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.arquillian</groupId>
+                <artifactId>wildfly-arquillian-container-managed</artifactId>
+                <version>${version.org.wildfly.arquillian}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan.arquillian.container</groupId>
+                <artifactId>infinispan-arquillian-impl</artifactId>
+                <version>${version.infinispan.arquillian}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.flink</groupId>
+                <artifactId>flink-java</artifactId>
+                <version>${version.flink}</version>
+                <scope>provided</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -175,7 +241,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${version.maven.compiler}</version>
+                    <version>${version.maven-compiler-plugin}</version>
                     <configuration>
                         <source>1.8</source>
                         <target>1.8</target>
@@ -189,13 +255,18 @@
                 </plugin>
 
                 <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${version.maven.javadoc}</version>
+                </plugin>
+
+                <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>${version.maven.resources}</version>
                 </plugin>
 
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.2</version>
+                    <version>${version.maven.release}</version>
                     <configuration>
                         <tagNameFormat>@{project.version}</tagNameFormat>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -51,4 +51,33 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>distribution</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>core/src/main/assembly/dist.xml</descriptor>
+                            </descriptors>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <finalName>${branding.prefix}-hadoop-aggregator-${branding.version}</finalName>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/samples/base/pom.xml
+++ b/samples/base/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>${version.hadoop}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/samples/flink/pom.xml
+++ b/samples/flink/pom.xml
@@ -15,10 +15,6 @@
     <name>Infinispan Hadoop Flink Sample</name>
     <description>Infinispan InputFormat/OutputFormat used by Flink</description>
 
-    <properties>
-        <version.flink>0.10.1</version.flink>
-    </properties>
-
     <dependencies>
 
         <dependency>
@@ -36,14 +32,12 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-java</artifactId>
-            <version>0.9.1</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>${version.hadoop}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -58,7 +52,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>${version.maven.shade}</version>
                 <executions>
                     <execution>
                         <id>none-default</id>

--- a/samples/mapreduce/pom.xml
+++ b/samples/mapreduce/pom.xml
@@ -32,21 +32,18 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-common</artifactId>
-            <version>${version.hadoop}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
-            <version>${version.hadoop}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>${version.hadoop}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -60,7 +57,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>${version.maven.shade}</version>
                 <executions>
                     <execution>
                         <id>none-default</id>


### PR DESCRIPTION
https://issues.jboss.org/browse/IHDP-19

Initial backport of downstream changes.

* I didn't see any reason to have infinispan as a parent. I removed that.
* Javadoc isn't generated automatically. Should it be?
* I've aligned the dependencies with infinispan 9.4.1.Final
* Should we create a `distribution` profile to create the zip and javadoc?