### PR TITLE
Use generate-test-resources phase withing plugin

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -162,7 +162,7 @@
                 <executions>
                     <execution>
                         <id>download-infinispan-server</id>
-                        <phase>generate-resources</phase>
+                        <phase>generate-test-resources</phase>
                         <goals>
                             <goal>wget</goal>
                         </goals>
@@ -183,7 +183,7 @@
                 <executions>
                     <execution>
                         <id>copy-resources</id>
-                        <phase>generate-resources</phase>
+                        <phase>generate-test-resources</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>


### PR DESCRIPTION
Changes the phase in which `wget` plugin gets triggered from `generate-soureces` to `generate-test-sources`. This phase is more appropriate since servers are downloaded for testing purposes and are now triggered in `test` phase instead `compile`.